### PR TITLE
Replace back buttons with persistent site navigation bar

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -42,6 +42,61 @@ body {
   position: relative;
 }
 
+/* ===== SITE NAVIGATION ===== */
+.site-nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  background: #000000;
+  border-bottom: 3px solid #000000;
+}
+
+.nav-inner {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  max-width: 100%;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.nav-inner::-webkit-scrollbar {
+  display: none;
+}
+
+.nav-link {
+  background: none;
+  border: none;
+  border-right: 1px solid rgba(255, 255, 255, 0.15);
+  color: #ffffff;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.85rem;
+  font-weight: 500;
+  padding: 1rem 1.5rem;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s ease, color 0.15s ease;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+}
+
+.nav-link:hover {
+  background: #ffffff;
+  color: #000000;
+}
+
+.nav-link--active {
+  background: #ffffff;
+  color: #000000;
+  font-weight: 700;
+}
+
+.nav-link--active:hover {
+  background: #f0f0f0;
+}
+
 /* ===== ART VIEW - PURE GRID EXPERIENCE ===== */
 .art-view {
   min-height: 100vh;
@@ -120,35 +175,15 @@ body {
   background: #f8f8f8;
   position: relative;
   overflow-y: auto;
-}
-
-.back-to-art-btn {
-  position: fixed;
-  top: 2rem;
-  left: 2rem;
-  background: #000000;
-  color: #ffffff;
-  border: none;
-  padding: 1rem 1.5rem;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 0.9rem;
-  cursor: pointer;
-  z-index: 1000;
-  transition: all 0.08s ease;
-  border: 2px solid #000000;
-}
-
-.back-to-art-btn:hover {
-  background: #ffffff;
-  color: #000000;
-  transform: translateY(-2px);
+  padding-top: calc(3px + 1rem + 0.85rem * 1.2 + 1rem);
+  /* nav height: border + padding-top + font + padding-bottom */
 }
 
 /* ===== MONDRIAN GRID LAYOUT ===== */
 .mondrian-portfolio {
   width: 100vw;
-  height: 100vh;
-  padding: 4rem 2rem 2rem;
+  height: calc(100vh - calc(3px + 1rem + 0.85rem * 1.2 + 1rem));
+  padding: 1rem 2rem 2rem;
 }
 
 .mondrian-grid {
@@ -356,31 +391,9 @@ body {
 /* ===== SECTION PAGES ===== */
 .section-page {
   min-height: 100vh;
-  padding: 4rem 2rem 2rem;
+  padding: calc(3px + 1rem + 0.85rem * 1.2 + 1rem + 2rem) 2rem 2rem;
   background: #f8f8f8;
   overflow-y: auto;
-}
-
-.back-to-portfolio-btn {
-  position: fixed;
-  top: 2rem;
-  right: 2rem;
-  background: #000000;
-  color: #ffffff;
-  border: none;
-  padding: 1rem 1.5rem;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 0.9rem;
-  cursor: pointer;
-  z-index: 1000;
-  transition: all 0.08s ease;
-  border: 2px solid #000000;
-}
-
-.back-to-portfolio-btn:hover {
-  background: #ffffff;
-  color: #000000;
-  transform: translateY(-2px);
 }
 
 .section-content {
@@ -918,7 +931,7 @@ blockquote {
   }
 
   .mondrian-portfolio {
-    padding: 4rem 1rem 2rem;
+    padding: 1rem 1rem 2rem;
   }
 
   .mondrian-grid {
@@ -988,25 +1001,15 @@ blockquote {
     grid-row: 9 / 10;
   }
 
-  .back-to-art-btn,
-  .back-to-portfolio-btn {
-    position: fixed;
-    top: 1rem;
-    left: 1rem;
-    right: auto;
-    padding: 0.8rem 1.2rem;
-    font-size: 0.8rem;
-    z-index: 1001;
-  }
-
-  .back-to-portfolio-btn {
-    left: auto;
-    right: 1rem;
+  /* Navigation Mobile */
+  .nav-link {
+    font-size: 0.75rem;
+    padding: 0.75rem 1rem;
   }
 
   /* Section Pages Mobile */
   .section-page {
-    padding: 3rem 1rem 2rem;
+    padding: calc(3px + 0.75rem + 0.75rem * 1.2 + 0.75rem + 1.5rem) 1rem 2rem;
   }
 
   .section-content {
@@ -1091,7 +1094,7 @@ blockquote {
 /* Small mobile devices */
 @media (max-width: 480px) {
   .mondrian-portfolio {
-    padding: 3rem 0.5rem 1rem;
+    padding: 0.5rem 0.5rem 1rem;
   }
 
   .mondrian-tile {
@@ -1108,18 +1111,17 @@ blockquote {
   }
 
   .section-page {
-    padding: 2.5rem 0.5rem 1rem;
+    padding: calc(3px + 0.75rem + 0.75rem * 1.2 + 0.75rem + 1rem) 0.5rem 1rem;
+  }
+
+  .nav-link {
+    font-size: 0.7rem;
+    padding: 0.6rem 0.75rem;
   }
 
   .project-card,
   .hobby-card {
     padding: 1rem;
-  }
-
-  .back-to-art-btn,
-  .back-to-portfolio-btn {
-    padding: 0.6rem 1rem;
-    font-size: 0.75rem;
   }
 }
 
@@ -1142,8 +1144,7 @@ canvas {
 }
 
 .grid-cell,
-.back-to-art-btn,
-.back-to-portfolio-btn,
+.nav-link,
 .project-item,
 .contact-methods a,
 .clickable-tile {
@@ -1223,8 +1224,7 @@ canvas {
   }
 
   .grid-cell,
-  .back-to-art-btn,
-  .back-to-portfolio-btn,
+  .nav-link,
   .project-item,
   .contact-methods a,
   .clickable-tile {

--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ import {
 	ArtView,
 	PortfolioView,
 	SectionView,
+	Navigation,
 } from "./components";
 import { ROUTES } from "./constants/routes";
 
@@ -27,6 +28,7 @@ function App() {
 		<div className="App">
 			<ErrorBoundary>
 				<BlobityProvider isArtView={isArtView} />
+				<Navigation />
 
 				<AnimatePresence mode="wait">
 					<Routes location={location} key={location.pathname}>

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -1,0 +1,50 @@
+import React from "react";
+import { useNavigate, useLocation } from "react-router-dom";
+import { motion } from "framer-motion";
+import { ROUTES } from "../constants/routes";
+
+const NAV_ITEMS = [
+	{ path: ROUTES.HOME, label: "Art" },
+	{ path: ROUTES.PORTFOLIO, label: "Portfolio" },
+	{ path: ROUTES.ABOUT, label: "About" },
+	{ path: ROUTES.PROJECTS, label: "Projects" },
+	{ path: ROUTES.SKILLS, label: "Skills" },
+	{ path: ROUTES.EXPERIENCE, label: "Experience" },
+	{ path: ROUTES.CONTACT, label: "Contact" },
+	{ path: ROUTES.MISC, label: "Misc" },
+];
+
+const Navigation = () => {
+	const navigate = useNavigate();
+	const location = useLocation();
+
+	// Don't show navigation on the art landing page
+	if (location.pathname === ROUTES.HOME) {
+		return null;
+	}
+
+	return (
+		<motion.nav
+			className="site-nav"
+			initial={{ y: -60, opacity: 0 }}
+			animate={{ y: 0, opacity: 1 }}
+			transition={{ duration: 0.4, ease: "easeOut" }}
+		>
+			<div className="nav-inner">
+				{NAV_ITEMS.map((item) => (
+					<button
+						key={item.path}
+						className={`nav-link${location.pathname === item.path ? " nav-link--active" : ""}`}
+						onClick={() => navigate(item.path)}
+						aria-label={`Go to ${item.label}`}
+						aria-current={location.pathname === item.path ? "page" : undefined}
+					>
+						{item.label}
+					</button>
+				))}
+			</div>
+		</motion.nav>
+	);
+};
+
+export default Navigation;

--- a/src/components/PortfolioView.js
+++ b/src/components/PortfolioView.js
@@ -3,7 +3,6 @@ import { useNavigate } from "react-router-dom";
 import { motion } from "framer-motion";
 import MondrianTile from "./MondrianTile";
 import { TILE_CONFIGS, COLOR_TILES, ANIMATION } from "../constants/config";
-import { ROUTES } from "../constants/routes";
 
 /**
  * Portfolio View Component
@@ -19,10 +18,6 @@ const PortfolioView = () => {
 		[navigate]
 	);
 
-	const handleBackToArt = useCallback(() => {
-		navigate(ROUTES.HOME);
-	}, [navigate]);
-
 	return (
 		<motion.div
 			key="portfolio"
@@ -32,14 +27,6 @@ const PortfolioView = () => {
 			exit={{ opacity: 0, scale: 1.1 }}
 			transition={{ duration: 0.6, ease: "easeInOut" }}
 		>
-			<button
-				className="back-to-art-btn"
-				onClick={handleBackToArt}
-				aria-label="Back to art view"
-			>
-				← Back to Art
-			</button>
-
 			<motion.div
 				key="grid"
 				className="mondrian-portfolio"

--- a/src/components/SectionView.js
+++ b/src/components/SectionView.js
@@ -1,9 +1,8 @@
-import React, { useCallback } from "react";
+import React from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { motion } from "framer-motion";
 import SectionPage from "./SectionPage";
-import { isValidSection } from "../constants/routes";
-import { ROUTES } from "../constants/routes";
+import { isValidSection, ROUTES } from "../constants/routes";
 
 /**
  * Section View Component
@@ -12,10 +11,6 @@ import { ROUTES } from "../constants/routes";
 const SectionView = () => {
 	const navigate = useNavigate();
 	const { section } = useParams();
-
-	const handleBackToPortfolio = useCallback(() => {
-		navigate(ROUTES.PORTFOLIO);
-	}, [navigate]);
 
 	// Redirect to portfolio if invalid section
 	if (!isValidSection(section)) {
@@ -32,13 +27,6 @@ const SectionView = () => {
 			exit={{ opacity: 0, x: -50 }}
 			transition={{ duration: 0.5 }}
 		>
-			<button
-				className="back-to-portfolio-btn"
-				onClick={handleBackToPortfolio}
-				aria-label="Back to portfolio"
-			>
-				← Back to Portfolio
-			</button>
 			<SectionPage section={section} />
 		</motion.div>
 	);

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -12,3 +12,4 @@ export { default as SectionPage } from "./SectionPage";
 export { default as ArtView } from "./ArtView";
 export { default as PortfolioView } from "./PortfolioView";
 export { default as SectionView } from "./SectionView";
+export { default as Navigation } from "./Navigation";

--- a/src/constants/config.js
+++ b/src/constants/config.js
@@ -117,7 +117,7 @@ export const BLOBITY_CONFIG = {
 	},
 	FONT: "JetBrains Mono",
 	FOCUSABLE_SELECTOR:
-		"a, button, .grid-cell, .mondrian-tile, .clickable-tile, .color-tile, .back-button, .project-item, .skill-category, .contact-method, .experience-item",
+		"a, button, .grid-cell, .mondrian-tile, .clickable-tile, .color-tile, .nav-link, .project-item, .skill-category, .contact-method, .experience-item",
 };
 
 // Color Mapping for Blobity Cursor (RGB values)


### PR DESCRIPTION
## Summary
Replaced fixed "back" buttons with a persistent, responsive site navigation bar that appears on all pages except the art landing page. This provides better navigation UX and a more cohesive site structure.

## Key Changes
- **New Navigation Component** (`Navigation.js`): Created a new persistent navigation bar with links to all major sections (Art, Portfolio, About, Projects, Skills, Experience, Contact, Misc)
  - Conditionally hidden on the home/art view page
  - Shows active state for current page
  - Includes smooth entrance animation via Framer Motion
  - Fully responsive with mobile-optimized font sizes and padding

- **Removed Back Buttons**: Eliminated `.back-to-art-btn` and `.back-to-portfolio-btn` from:
  - `PortfolioView.js` - removed "← Back to Art" button
  - `SectionView.js` - removed "← Back to Portfolio" button
  - Associated CSS styles and mobile breakpoint overrides

- **Updated Layout Spacing**: Adjusted padding calculations across views to account for fixed navigation bar height:
  - `.mondrian-portfolio` and `.section-page` now include nav height in padding calculations
  - Maintains consistent spacing across desktop and mobile breakpoints

- **CSS Enhancements**:
  - Added `.site-nav` styles with fixed positioning and z-index management
  - Added `.nav-link` and `.nav-link--active` styles with hover effects and transitions
  - Updated Blobity cursor selector to include `.nav-link` instead of removed button classes

- **Integration**: Added `Navigation` component to `App.js` root level for global availability

## Notable Implementation Details
- Navigation uses React Router's `useLocation()` to determine active state
- Horizontal scrolling support for nav items on smaller screens (scrollbar hidden)
- Responsive design with adjusted font sizes and padding for tablet and mobile
- Maintains accessibility with proper ARIA labels and semantic button elements

https://claude.ai/code/session_01YFJRZvMykhUrXMkQYjjq73